### PR TITLE
Implement Plex client listing

### DIFF
--- a/plugs/plex_plug/plex_manager.py
+++ b/plugs/plex_plug/plex_manager.py
@@ -19,4 +19,13 @@ class PlexManager(ParentManager):
             self.base_url = self.config['base_url']
             self.token = os.environ['X_PLEX_TOKEN']
             self.server = PlexServer(self.base_url, self.token)
-            self.plex_account = MyPlexAccount(token=self._token)
+            self.plex_account = MyPlexAccount(token=self.token)
+
+    def print_known_clients(self):
+        """Print all the clients known to the Plex account."""
+        clients = []
+        for resource in self.plex_account.resources():
+            if "player" in resource.provides:
+                print(resource.name)
+                clients.append(resource.name)
+        return clients


### PR DESCRIPTION
## Summary
- fix the Plex account initialization
- add `print_known_clients` to show all clients connected to the Plex account

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68601ef33b788331a5e6b5a6d45bfaa1