### PR TITLE
Reuse manager instances

### DIFF
--- a/command_interpreter.py
+++ b/command_interpreter.py
@@ -8,6 +8,10 @@ logger = logging.getLogger(__name__)
 class CommandInterpreter:
     def __init__(self, configuration):
         self.configuration = configuration
+        available_managers = self.configuration.get('available_managers', [])
+        self.hue_manager = HueManager() if 'hue' in available_managers else None
+        self.home_assistant_manager = HomeAssistantManager() if 'home_assistant' in available_managers else None
+        self.roborock_manager = RoborockManager() if 'roborock' in available_managers else None
 
     def handle_command(self, command):
         manager_name = command['manager_name']
@@ -15,15 +19,12 @@ class CommandInterpreter:
         if manager_name not in available_managers:
             logger.error("Manager %s is not available", manager_name)
             return
-        if manager_name == 'hue':
-            hue_manager = HueManager()
-            hue_manager.handle_command(command)
-        elif manager_name == 'home_assistant':
-            home_assistant_manager = HomeAssistantManager()
-            home_assistant_manager.handle_command(command)
-        elif manager_name == 'roborock':
-            roborock_manager = RoborockManager()
-            roborock_manager.handle_command(command)
+        if manager_name == 'hue' and self.hue_manager:
+            self.hue_manager.handle_command(command)
+        elif manager_name == 'home_assistant' and self.home_assistant_manager:
+            self.home_assistant_manager.handle_command(command)
+        elif manager_name == 'roborock' and self.roborock_manager:
+            self.roborock_manager.handle_command(command)
 
     def handle_request(self, command_as_json):
         for command in command_as_json:


### PR DESCRIPTION
## Summary
- optimize `CommandInterpreter` by creating `HueManager`, `HomeAssistantManager`,
  and `RoborockManager` once in `__init__`
- reuse these managers for incoming commands

## Testing
- `python -m py_compile command_interpreter.py`


------
https://chatgpt.com/codex/tasks/task_e_687fe6150d988331b99713fba072be8b