### PR TITLE
Add wake-word detection pipeline to assistant listener

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from services.file_logger import FileLoggerService
 from services.sentry_service import SentryService
 from speaker import Speaker
 from datetime import datetime
+from wake_word_detector import WakeWordDetector
 
 logger = logging.getLogger(__name__)
 file_logger = FileLoggerService("logs/stt.log")
@@ -24,6 +25,7 @@ class Main:
             self.ci = CommandInterpreter(self.configuration)
             self.speaker = Speaker()
             self.command_understanding = CommandUnderstander(configuration=self.configuration)
+            self.wake_word_detector = WakeWordDetector(configuration=self.configuration)
 
     def main(self):
         SentryService()
@@ -41,28 +43,57 @@ class Main:
         self.speaker.say(llm_answer_as_json['answer'])
 
     def constant_listening(self, recognizer):
-        with sr.Microphone() as source:
+        microphone = sr.Microphone()
+
+        with microphone as source:
             logger.info("Calibrating microphone... Please wait.")
             recognizer.adjust_for_ambient_noise(source, duration=5)
             logger.info("Microphone calibrated. Start speaking.")
 
-            while True:
-                try:
-                    audio = recognizer.listen(source, timeout=0.5, phrase_time_limit=10)
+        while True:
+            try:
+                detection = self.wake_word_detector.wait_for_activation(
+                    recognizer=recognizer,
+                    language=self.configuration.get("language", "fr-FR"),
+                    device_index=microphone.device_index,
+                )
+
+                if detection.command_text:
+                    text = detection.command_text
+                else:
+                    logger.info("Wake word detected. Waiting for command.")
+                    with microphone as source:
+                        audio = recognizer.listen(
+                            source,
+                            timeout=self.configuration.get("command_timeout", 5),
+                            phrase_time_limit=self.configuration.get("command_phrase_time_limit", 15),
+                        )
+
                     start = datetime.now()
-                    text = recognizer.recognize_google(audio, language="fr-FR")
+                    text = recognizer.recognize_google(
+                        audio,
+                        language=self.configuration.get("language", "fr-FR"),
+                    )
                     end = datetime.now()
                     delta = end - start
-                    file_logger.info(f"{end} transcript command in {delta.total_seconds() * 1000} milliseconds", )
-                    if (self.configuration['assistant_name'] in text):
-                        self.__handle_command(text)
+                    file_logger.info(
+                        f"{end} transcript command in {delta.total_seconds() * 1000} milliseconds",
+                    )
 
-                except sr.WaitTimeoutError:
-                    logger.warning("Listening timed out while waiting for phrase to start")
-                except sr.UnknownValueError:
-                    logger.warning("Google Speech Recognition could not understand audio")
-                except sr.RequestError as e:
-                    logger.error("Could not request results from Google Speech Recognition service; %s", e)
+                    if self.configuration['assistant_name'].lower() not in text.lower():
+                        text = f"{self.configuration['assistant_name']} {text}".strip()
+
+                if self.configuration['assistant_name'].lower() in text.lower():
+                    self.__handle_command(text)
+                else:
+                    logger.info("Ignoring command without wake word: %s", text)
+
+            except sr.WaitTimeoutError:
+                logger.warning("Listening timed out while waiting for phrase to start")
+            except sr.UnknownValueError:
+                logger.warning("Google Speech Recognition could not understand audio")
+            except sr.RequestError as e:
+                logger.error("Could not request results from Google Speech Recognition service; %s", e)
 
     def test_chat(self):
         while True:

--- a/wake_word_detector.py
+++ b/wake_word_detector.py
@@ -1,0 +1,162 @@
+import logging
+import struct
+from dataclasses import dataclass
+from typing import Optional
+
+import speech_recognition as sr
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WakeWordDetectionResult:
+    """Represents the outcome of a wake-word detection."""
+
+    command_text: Optional[str] = None
+
+    @property
+    def requires_follow_up_recording(self) -> bool:
+        return self.command_text is None
+
+
+class BaseWakeWordDetector:
+    """Base class for wake-word detectors."""
+
+    def wait_for_activation(self) -> WakeWordDetectionResult:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class PorcupineWakeWordDetector(BaseWakeWordDetector):
+    """Wake-word detector powered by pvporcupine."""
+
+    def __init__(self, keyword_path: str, sensitivity: float = 0.5, device_index: Optional[int] = None):
+        try:
+            import pvporcupine
+            import pyaudio
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("pvporcupine is required for the Porcupine wake-word detector") from exc
+
+        self._pvporcupine = pvporcupine.create(keyword_paths=[keyword_path], sensitivities=[sensitivity])
+        self._pyaudio = pyaudio.PyAudio()
+        self._device_index = device_index
+        self._stream = None
+
+    def _open_stream(self):
+        import pyaudio
+
+        if self._stream is None:
+            self._stream = self._pyaudio.open(
+                rate=self._pvporcupine.sample_rate,
+                channels=1,
+                format=pyaudio.paInt16,
+                input=True,
+                frames_per_buffer=self._pvporcupine.frame_length,
+                input_device_index=self._device_index,
+            )
+
+    def wait_for_activation(self) -> WakeWordDetectionResult:
+        self._open_stream()
+        logger.info("Listening for wake word with Porcupine detector…")
+
+        while True:
+            pcm = self._stream.read(self._pvporcupine.frame_length, exception_on_overflow=False)
+            pcm_unpacked = struct.unpack_from("h" * self._pvporcupine.frame_length, pcm)
+            if self._pvporcupine.process(pcm_unpacked) >= 0:
+                logger.info("Wake word detected by Porcupine.")
+                return WakeWordDetectionResult()
+
+    def close(self):  # pragma: no cover - resource cleanup
+        if self._stream is not None:
+            self._stream.stop_stream()
+            self._stream.close()
+            self._stream = None
+        if self._pyaudio is not None:
+            self._pyaudio.terminate()
+
+
+class SpeechRecognitionWakeWordDetector(BaseWakeWordDetector):
+    """Fallback detector relying on speech recognition for keyword spotting."""
+
+    def __init__(
+        self,
+        recognizer: sr.Recognizer,
+        assistant_name: str,
+        language: str = "fr-FR",
+        listen_timeout: float = 3.0,
+        device_index: Optional[int] = None,
+    ):
+        self._recognizer = recognizer
+        self._assistant_name = assistant_name.lower()
+        self._language = language
+        self._listen_timeout = listen_timeout
+        self._device_index = device_index
+
+    def wait_for_activation(self) -> WakeWordDetectionResult:
+        logger.info("Listening for wake word with speech recognition fallback…")
+
+        while True:
+            with sr.Microphone(device_index=self._device_index) as source:
+                audio = self._recognizer.listen(source, timeout=None, phrase_time_limit=self._listen_timeout)
+
+            try:
+                transcription = self._recognizer.recognize_google(audio, language=self._language)
+                logger.debug("Wake-word fallback transcription: %s", transcription)
+            except sr.UnknownValueError:
+                logger.debug("Wake-word fallback could not understand audio.")
+                continue
+            except sr.RequestError as error:  # pragma: no cover - network failure
+                logger.error("Wake-word fallback request error: %s", error)
+                continue
+
+            normalized = transcription.lower()
+            if self._assistant_name in normalized:
+                logger.info("Wake word detected through fallback recognizer.")
+                remainder = normalized.replace(self._assistant_name, "", 1).strip()
+                if remainder:
+                    return WakeWordDetectionResult(command_text=transcription)
+                return WakeWordDetectionResult()
+
+
+class WakeWordDetector:
+    """Facade that selects the best wake-word strategy based on configuration."""
+
+    def __init__(self, configuration):
+        self._configuration = configuration
+
+    def wait_for_activation(
+        self,
+        recognizer: sr.Recognizer,
+        language: str = "fr-FR",
+        device_index: Optional[int] = None,
+    ) -> WakeWordDetectionResult:
+        wake_word_configuration = self._configuration.get("wake_word", {})
+
+        keyword_path = wake_word_configuration.get("porcupine_keyword_path")
+        sensitivity = wake_word_configuration.get("porcupine_sensitivity", 0.6)
+
+        if keyword_path:
+            try:
+                detector = PorcupineWakeWordDetector(
+                    keyword_path=keyword_path,
+                    sensitivity=sensitivity,
+                    device_index=device_index,
+                )
+                try:
+                    return detector.wait_for_activation()
+                finally:
+                    detector.close()
+            except RuntimeError:
+                logger.warning(
+                    "pvporcupine is not available. Falling back to speech-recognition-based wake-word detection.",
+                )
+
+        fallback_timeout = wake_word_configuration.get("fallback_listen_timeout", 3.0)
+        detector = SpeechRecognitionWakeWordDetector(
+            recognizer=recognizer,
+            assistant_name=self._configuration.get("assistant_name", ""),
+            language=language,
+            listen_timeout=fallback_timeout,
+            device_index=device_index,
+        )
+        return detector.wait_for_activation()


### PR DESCRIPTION
## Summary
- introduce a wake-word detector that prefers Porcupine and falls back to speech-recognition keyword spotting
- update the listening loop to gate command transcription until the wake word fires and to reuse existing phrases when possible

## Testing
- python -m compileall main.py wake_word_detector.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135ec1ece88331a8bed9f943945a95)